### PR TITLE
Fix piwik

### DIFF
--- a/content/libraries/piwik.md
+++ b/content/libraries/piwik.md
@@ -3,6 +3,8 @@ title: Piwik
 contributors:
   - user:   halfdan
     name:   Fabian Becker
+  - user:   makkrnic
+    name:   Mak Krnic
 ---
 
 # Piwik - Open Source Web Analytics
@@ -17,4 +19,11 @@ $(document).on 'page:change', ->
     _paq.push ['trackPageView']
   else if window.piwikTracker?
     piwikTracker.trackPageview()
+```
+
+Also, you will probably want to include the following code after `var _paq = _paq || [];` to the body snippet so tracked title and url are updated accordingly:
+
+```javascript
+_paq.push(['setCustomUrl', document.location]);
+_paq.push(['setDocumentTitle', document.title]);
 ```


### PR DESCRIPTION
025b80f
If using `_paq.push(['trackPageview'])` an error appears "TypeError: L[Y] is undefined". That is fixed by camel casing trackPageView.

f7eb403
Piwik sets the page title and url only on initialization so this helps to get more accurate information.
