### PR TITLE
Better compatibility with jquery.turbolinks

### DIFF
--- a/content/libraries/facebook.md
+++ b/content/libraries/facebook.md
@@ -48,8 +48,10 @@ fb_root = null
 fb_events_bound = false
 
 $ ->
-  loadFacebookSDK()
-  bindFacebookEvents() unless fb_events_bound
+  unless fb_events_bound
+    loadFacebookSDK()
+    bindFacebookEvents()
+    fb_events_bound = true
 
 bindFacebookEvents = ->
   $(document)
@@ -58,7 +60,6 @@ bindFacebookEvents = ->
     .on('page:load', ->
       FB?.XFBML.parse()
     )
-  fb_events_bound = true
 
 saveFacebookRoot = ->
   fb_root = $('#fb-root').detach()


### PR DESCRIPTION
[jquery.turbolinks](https://github.com/kossnocorp/jquery.turbolinks) makes $() to fire on each page load. But Facebook SDK should be loaded only once, so we need additional check.