### PR TITLE
Fix "sdk.js:89 Uncaught Error: invalid version specified"

### DIFF
--- a/content/libraries/facebook.md
+++ b/content/libraries/facebook.md
@@ -81,6 +81,7 @@ initializeFacebookSDK = ->
     status : true
     cookie : true
     xfbml  : true
+    version: 'v2.7'
 ```
 
 *This solution is implemented on this site.*


### PR DESCRIPTION
It seems like you have to specify a version number in FB.init, otherwise I get the error "sdk.js:89 Uncaught Error: invalid version specified" and the plugins don't load